### PR TITLE
Move step install everest-testing to github workflow

### DIFF
--- a/docker/images/build-kit/alpine.Dockerfile
+++ b/docker/images/build-kit/alpine.Dockerfile
@@ -72,9 +72,6 @@ RUN python3 -m pip install \
 # install ev-cli
 RUN python3 -m pip install git+https://github.com/EVerest/everest-utils@4a5ce956722929325cef3c2d73a8919c6d2e4013#subdirectory=ev-dev-tools
 
-# install everest-testing
-RUN python3 -m pip install git+https://github.com/EVerest/everest-utils@v0.1.6#subdirectory=everest-testing
-
 # install edm
 RUN python3 -m pip install git+https://github.com/EVerest/everest-dev-environment@v0.5.5#subdirectory=dependency_manager
 

--- a/docker/images/build-kit/debian.Dockerfile
+++ b/docker/images/build-kit/debian.Dockerfile
@@ -64,9 +64,6 @@ RUN python3 -m pip install \
 # install ev-cli
 RUN python3 -m pip install git+https://github.com/EVerest/everest-utils@4a5ce956722929325cef3c2d73a8919c6d2e4013#subdirectory=ev-dev-tools
 
-# install everest-testing
-RUN python3 -m pip install git+https://github.com/EVerest/everest-utils@v0.1.6#subdirectory=everest-testing
-
 # install edm
 RUN python3 -m pip install git+https://github.com/EVerest/everest-dev-environment@v0.5.5#subdirectory=dependency_manager
 


### PR DESCRIPTION
* Remove install step of everest-testing in Dockerfile, since it is moved to github workflow

requires:
* https://github.com/EVerest/everest-core/pull/475