### PR TITLE
Add libcap-dev dependency to Dockerfiles

### DIFF
--- a/docker/images/build-kit/alpine.Dockerfile
+++ b/docker/images/build-kit/alpine.Dockerfile
@@ -55,8 +55,10 @@ RUN apk add --no-cache \
         maven \
         # required by pybind11
         python3-dev \
-	# required for certificate generation
-	openssl
+        # required for certificate generation
+        openssl \
+        # required for user and capability support in everest-framework >= 0.9.0
+        libcap-dev
 
 RUN python3 -m pip install \
     environs>=9.5.0 \

--- a/docker/images/build-kit/debian.Dockerfile
+++ b/docker/images/build-kit/debian.Dockerfile
@@ -44,7 +44,9 @@ RUN apt-get install --no-install-recommends -y \
         pkg-config \
         libpcap-dev \
         # required by RiseV2G
-        maven
+        maven \
+        # required for user and capability support in everest-framework >= 0.9.0
+        libcap-dev
 
 # clean up apt
 RUN apt-get clean \


### PR DESCRIPTION
This is required for user and capability support in everest-framework >= 0.9.0