### PR TITLE
Do not install ev-cli, enable building wheels

### DIFF
--- a/docker/images/build-kit/alpine.Dockerfile
+++ b/docker/images/build-kit/alpine.Dockerfile
@@ -81,7 +81,7 @@ RUN git clone https://github.com/EVerest/everest-cmake.git $EVEREST_CMAKE_PATH
 
 RUN ( \
     cd $EVEREST_CMAKE_PATH \
-    git checkout 329f8db \
+    git checkout v0.3.0 \
     rm -r .git \
     )
 

--- a/docker/images/build-kit/alpine.Dockerfile
+++ b/docker/images/build-kit/alpine.Dockerfile
@@ -81,7 +81,7 @@ RUN git clone https://github.com/EVerest/everest-cmake.git $EVEREST_CMAKE_PATH
 
 RUN ( \
     cd $EVEREST_CMAKE_PATH \
-    git checkout v0.3.0 \
+    git checkout v0.4.0 \
     rm -r .git \
     )
 

--- a/docker/images/build-kit/alpine.Dockerfile
+++ b/docker/images/build-kit/alpine.Dockerfile
@@ -70,11 +70,8 @@ RUN python3 -m pip install \
     py4j>=0.10.9.5 \
     netifaces>=0.11.0 \
     python-dateutil>=2.8.2 \
-    gcovr==5.0
-
-# install ev-cli
-ARG EVEREST_UTILS_VERSION=v0.2.3
-RUN python3 -m pip install git+https://github.com/EVerest/everest-utils@${EVEREST_UTILS_VERSION}#subdirectory=ev-dev-tools
+    gcovr==5.0 \
+    build
 
 # install edm
 RUN python3 -m pip install git+https://github.com/EVerest/everest-dev-environment@v0.5.5#subdirectory=dependency_manager

--- a/docker/images/build-kit/debian.Dockerfile
+++ b/docker/images/build-kit/debian.Dockerfile
@@ -61,11 +61,8 @@ RUN python3 -m pip install \
     py4j>=0.10.9.5 \
     netifaces>=0.11.0 \
     python-dateutil>=2.8.2 \
-    gcovr==5.0
-
-# install ev-cli
-ARG EVEREST_UTILS_VERSION=v0.2.3
-RUN python3 -m pip install git+https://github.com/EVerest/everest-utils@${EVEREST_UTILS_VERSION}#subdirectory=ev-dev-tools
+    gcovr==5.0 \
+    build
 
 # install edm
 RUN python3 -m pip install git+https://github.com/EVerest/everest-dev-environment@v0.5.5#subdirectory=dependency_manager

--- a/docker/images/build-kit/debian.Dockerfile
+++ b/docker/images/build-kit/debian.Dockerfile
@@ -72,7 +72,7 @@ RUN git clone https://github.com/EVerest/everest-cmake.git $EVEREST_CMAKE_PATH
 
 RUN ( \
     cd $EVEREST_CMAKE_PATH \
-    git checkout v0.3.0 \
+    git checkout v0.4.0 \
     rm -r .git \
     )
 

--- a/docker/images/build-kit/debian.Dockerfile
+++ b/docker/images/build-kit/debian.Dockerfile
@@ -72,7 +72,7 @@ RUN git clone https://github.com/EVerest/everest-cmake.git $EVEREST_CMAKE_PATH
 
 RUN ( \
     cd $EVEREST_CMAKE_PATH \
-    git checkout 329f8db \
+    git checkout v0.3.0 \
     rm -r .git \
     )
 


### PR DESCRIPTION
## Changes
* Add install build
* Do not install ev-cli

## Requires
* https://github.com/EVerest/everest-cmake/pull/4
* https://github.com/EVerest/everest-cmake/pull/3

## TODO before merging
- [x] Bump everest-cmake in Dockerfile

## TODO after merge
- [ ] Release/Tag & Deploy a new version