### PR TITLE
Use artifacts instead of GHCR for build-kit-<reponame>

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -115,7 +115,7 @@ on:
       docker_compose_file_path:
         description: 'The path to the docker-compose file, relative to the repository root'
         required: false
-        default: '.ci/e2e/docker-compose.yml'
+        default: '.ci/e2e/docker-compose.yaml'
         type: string
       integration_image_name:
         description: 'The name of the integration image'

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -251,7 +251,7 @@ jobs:
 
           echo "latest_tag=$TAG" >> $GITHUB_OUTPUT
 
-  build-build-kit:
+  build-the-build-kit:
     name: Build build-kit
     runs-on: ${{ inputs.runner }}
     needs:
@@ -312,10 +312,10 @@ jobs:
     name: Build, Unit Tests and Install
     needs:
       - setup-env
-      - build-build-kit
+      - build-the-build-kit
     runs-on: ${{ inputs.runner }}
     env:
-      BUILD_KIT_IMAGE: ${{ needs.build-build-kit.outputs.build_kit_image_tag }}
+      BUILD_KIT_IMAGE: ${{ needs.build-the-build-kit.outputs.build_kit_image_tag }}
     steps:
       - name: Checkout local github actions
         uses: actions/checkout@v3
@@ -448,9 +448,9 @@ jobs:
     needs:
       - setup-env
       - build
-      - build-build-kit
+      - build-the-build-kit
     env:
-      BUILD_KIT_IMAGE: ${{ needs.build-build-kit.outputs.build_kit_image_tag }}
+      BUILD_KIT_IMAGE: ${{ needs.build-the-build-kit.outputs.build_kit_image_tag }}
     runs-on: ${{ inputs.runner }}
     if: ${{ inputs.run_integration_tests == 'true' }}
     steps:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -493,8 +493,9 @@ jobs:
       - name: Run integration tests
         id: run_integration_tests
         run: |
-          docker compose run \
+          docker compose \
           -f source/${{ inputs.docker_compose_file_path }} \
+          run \
           ${{ inputs.test_service_name }} \
           run-script run_integration_tests
       - name: Upload result and report as artifact

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -282,7 +282,7 @@ jobs:
       - name: Build
         uses: docker/build-push-action@v6
         with:
-          context: ${{ inputs.build_kit_docker_directory }}
+          context: source/${{ inputs.build_kit_docker_directory }}
           push: false
           platforms: ${{ env.PLATFORMS }}
           cache-from: type=gha

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -250,39 +250,61 @@ jobs:
           fi
 
           echo "latest_tag=$TAG" >> $GITHUB_OUTPUT
-  
-  build-and-push-build-kit:
-    name: Build and Push Build Kit
-    uses: everest/everest-ci/.github/workflows/deploy-single-docker-image.yml@v1.3.1
+
+  build-build-kit:
+    name: Build build-kit
+    runs-on: ${{ inputs.runner }}
     needs:
       - setup-env
-    permissions:
-      contents: read
-      packages: write
-    secrets:
-      SA_GITHUB_USERNAME: ${{ github.actor }}
-      SA_GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    with:
-      image_name: ${{ github.event.repository.name }}/build-kit-${{ github.event.repository.name }}
-      directory: ${{ inputs.build_kit_docker_directory}}
-      docker_registry: ${{ inputs.docker_registry }}
-      github_ref_before: ${{ github.event.before }}
-      github_ref_after: ${{ github.event.after }}
-      platforms: linux/amd64
-      depends_on_paths: |
-        ${{ inputs.build_kit_scripts_directory }}
-        ${{ needs.setup-env.outputs.workflow_path }}
-      build_args: |
+    env:
+      BUILD_KIT_IMAGE_NAME: local/build-kit-${{ github.event.repository.name }}
+      PLATFORMS: linux/amd64
+      BUILD_ARGS: |
         BASE_IMAGE_TAG=${{ needs.setup-env.outputs.tag_everest_ci }}
-  
+    outputs:
+      build_kit_image_name: ${{ env.BUILD_KIT_IMAGE_NAME }}
+    steps:
+      - name: Checkout Dockerfile
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}
+          path: source
+          ref: ${{ github.ref }}
+          token: ${{ github.token}}
+          fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: ${{ env.PLATFORMS }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.build_kit_docker_directory }}
+          push: false
+          platforms: ${{ env.PLATFORMS }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: ${{ env.BUILD_ARGS }}
+      - name: Save build-kit image
+        run: |
+          docker save ${{ env.BUILD_KIT_IMAGE_NAME }} -o build-kit.tar
+      - name: Upload build-kit image
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-kit
+          path: build-kit.tar
+
   build:
     name: Build, Unit Tests and Install
     needs:
       - setup-env
-      - build-and-push-build-kit
+      - build-build-kit
     runs-on: ${{ inputs.runner }}
     env:
-      BUILD_KIT_IMAGE: ${{ needs.build-and-push-build-kit.outputs.one_image_tag_long }}
+      BUILD_KIT_IMAGE: ${{ needs.build-build-kit.outputs.build_kit_image_name }}
     steps:
       - name: Checkout local github actions
         uses: actions/checkout@v3
@@ -312,9 +334,13 @@ jobs:
         run: |
           mkdir scripts
           rsync -a source/${{ inputs.build_kit_scripts_directory }}/ scripts
-      - name: Pull build-kit image
+      - name: Download build-kit image
+        uses: actions/download-artifact@v4
+        with:
+          name: build-kit
+      - name: Load build-kit image
         run: |
-          docker pull --quiet ${{ env.BUILD_KIT_IMAGE }}
+          docker load -i build-kit.tar
           docker image tag ${{ env.BUILD_KIT_IMAGE }} build-kit
       - name: Compile
         run: |
@@ -411,9 +437,9 @@ jobs:
     needs:
       - setup-env
       - build
-      - build-and-push-build-kit
+      - build-build-kit
     env:
-      BUILD_KIT_IMAGE: ${{ needs.build-and-push-build-kit.outputs.one_image_tag_long }}
+      BUILD_KIT_IMAGE: ${{ needs.build-build-kit.outputs.build_kit_image_name }}
     runs-on: ${{ inputs.runner }}
     if: ${{ inputs.run_integration_tests == 'true' }}
     steps:
@@ -438,9 +464,13 @@ jobs:
         run: |
           mkdir scripts
           rsync -a source/${{ inputs.build_kit_scripts_directory }}/ scripts
-      - name: Pull build-kit image
+      - name: Download build-kit image
+        uses: actions/download-artifact@v4
+        with:
+          name: build-kit
+      - name: Load build-kit image
         run: |
-          docker pull --quiet ${{ env.BUILD_KIT_IMAGE }}
+          docker load -i build-kit.tar
           docker image tag ${{ env.BUILD_KIT_IMAGE }} build-kit
       - name: Create integration-image
         run: |

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -258,11 +258,10 @@ jobs:
       - setup-env
     env:
       BUILD_KIT_IMAGE_NAME: local/build-kit-${{ github.event.repository.name }}
-      PLATFORMS: linux/amd64
       BUILD_ARGS: |
         BASE_IMAGE_TAG=${{ needs.setup-env.outputs.tag_everest_ci }}
     outputs:
-      build_kit_image_name: ${{ env.BUILD_KIT_IMAGE_NAME }}
+      build_kit_image_tag: ${{ steps.set-outputs.outputs.tag }}
     steps:
       - name: Checkout Dockerfile
         uses: actions/checkout@v4
@@ -272,29 +271,40 @@ jobs:
           ref: ${{ github.ref }}
           token: ${{ github.token}}
           fetch-depth: 0
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Docker Meta
+        id: meta
+        uses: docker/metadata-action@v5
         with:
-          image: tonistiigi/binfmt:latest
-          platforms: ${{ env.PLATFORMS }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+          images: ${{ env.BUILD_KIT_IMAGE_NAME }}
       - name: Build
         uses: docker/build-push-action@v6
         with:
           context: source/${{ inputs.build_kit_docker_directory }}
           push: false
-          platforms: ${{ env.PLATFORMS }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: ${{ env.BUILD_ARGS }}
-          tags: ${{ env.BUILD_KIT_IMAGE_NAME }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           outputs: type=docker,dest=build-kit.tar
       - name: Upload build-kit image
         uses: actions/upload-artifact@v4
         with:
           name: build-kit
           path: build-kit.tar
+      - name: Set output tag
+        id: set-outputs
+        shell: python3 {0}
+        run: |
+          import os
+          tags = "${{ steps.meta.outputs.tags }}".split(",")
+          if len(tags) == 0:
+            print("No tags found!❌")
+            exit(1)
+          tag = tags[0]
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+            f.write(f"tag={tag}\n")
+            print(f"Set tag={tag}")
 
   build:
     name: Build, Unit Tests and Install
@@ -303,7 +313,7 @@ jobs:
       - build-build-kit
     runs-on: ${{ inputs.runner }}
     env:
-      BUILD_KIT_IMAGE: ${{ needs.build-build-kit.outputs.build_kit_image_name }}
+      BUILD_KIT_IMAGE: ${{ needs.build-build-kit.outputs.build_kit_image_tag }}
     steps:
       - name: Checkout local github actions
         uses: actions/checkout@v3
@@ -438,7 +448,7 @@ jobs:
       - build
       - build-build-kit
     env:
-      BUILD_KIT_IMAGE: ${{ needs.build-build-kit.outputs.build_kit_image_name }}
+      BUILD_KIT_IMAGE: ${{ needs.build-build-kit.outputs.build_kit_image_tag }}
     runs-on: ${{ inputs.runner }}
     if: ${{ inputs.run_integration_tests == 'true' }}
     steps:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -504,7 +504,7 @@ jobs:
         with:
           if-no-files-found: error
           name: integration-test-report
-          path:
+          path: |
             ${{ inputs.result_xml_path }}
             ${{ inputs.report_html_path }}
       - name: Render result

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -288,7 +288,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: ${{ env.BUILD_ARGS }}
-          tags: ${{ env.BUILD_KIT_IMAGE_NAME }}
+          outputs: type=image,name=${{ env.BUILD_KIT_IMAGE_NAME }}
       - name: Save build-kit image
         run: |
           docker save ${{ env.BUILD_KIT_IMAGE_NAME }} -o build-kit.tar

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -288,6 +288,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: ${{ env.BUILD_ARGS }}
+          tags: ${{ env.BUILD_KIT_IMAGE_NAME }}
       - name: Save build-kit image
         run: |
           docker save ${{ env.BUILD_KIT_IMAGE_NAME }} -o build-kit.tar

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -257,7 +257,7 @@ jobs:
     needs:
       - setup-env
     env:
-      BUILD_KIT_IMAGE_NAME: local/build-kit-${{ github.event.repository.name }}
+      BUILD_KIT_IMAGE_NAME: local/build-kit-${{ github.event.repository.name }}:latest
       PLATFORMS: linux/amd64
       BUILD_ARGS: |
         BASE_IMAGE_TAG=${{ needs.setup-env.outputs.tag_everest_ci }}
@@ -288,7 +288,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: ${{ env.BUILD_ARGS }}
-          outputs: type=image,name=${{ env.BUILD_KIT_IMAGE_NAME }}
           tags: ${{ env.BUILD_KIT_IMAGE_NAME }}
       - name: Save build-kit image
         run: |

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -257,7 +257,7 @@ jobs:
     needs:
       - setup-env
     env:
-      BUILD_KIT_IMAGE_NAME: local/build-kit-${{ github.event.repository.name }}:latest
+      BUILD_KIT_IMAGE_NAME: local/build-kit-${{ github.event.repository.name }}
       PLATFORMS: linux/amd64
       BUILD_ARGS: |
         BASE_IMAGE_TAG=${{ needs.setup-env.outputs.tag_everest_ci }}
@@ -289,9 +289,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: ${{ env.BUILD_ARGS }}
           tags: ${{ env.BUILD_KIT_IMAGE_NAME }}
-      - name: Save build-kit image
-        run: |
-          docker save ${{ env.BUILD_KIT_IMAGE_NAME }} -o build-kit.tar
+          outputs: type=docker,dest=build-kit.tar
       - name: Upload build-kit image
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -276,6 +276,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.BUILD_KIT_IMAGE_NAME }}
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
       - name: Build
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -289,6 +289,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: ${{ env.BUILD_ARGS }}
           outputs: type=image,name=${{ env.BUILD_KIT_IMAGE_NAME }}
+          tags: ${{ env.BUILD_KIT_IMAGE_NAME }}
       - name: Save build-kit image
         run: |
           docker save ${{ env.BUILD_KIT_IMAGE_NAME }} -o build-kit.tar


### PR DESCRIPTION
When running the forklow in a PR coming from a fork it is not possible to push to the Github Container Registry since secrets are not available in a "fork run".

* Store build-kit-<reponame> in `build-kit.tar` and upload as artifact
* Download artifact and load docker image from `build-kit.tar`