### PR TITLE
Use CSV for output tags of docker meta action

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -276,6 +276,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.BUILD_KIT_IMAGE_NAME }}
+          sep-tags: ","
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
       - name: Build


### PR DESCRIPTION
In case of docker meta action iis returning multiple tags as output the `\n` was used as separator which isn't compatible with the `set-outputs` action.

This PR changes it to use a comma separated list instead.