### PR TITLE
Update canonical/get-workflow-version-action to v1.0.1

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -236,7 +236,7 @@ jobs:
           print(f"Set output workflow_path to {workflow_path}")
       - name: Determine SHA of the reusable workflow
         id: set_sha_everest_ci
-        uses: canonical/get-workflow-version-action@v1.0.0
+        uses: canonical/get-workflow-version-action@v1.0.1
         with:
           repository-name:  everest/everest-ci
           file-name: continuous_integration.yml


### PR DESCRIPTION
v1.0.0 has a minor security issue where the GITHUB_TOKEN can be partially leaked if the the get-workflow-version-action step fails

The impact of that issue is limited since the GITHUB_TOKEN is short-lived and automatically revoked at the end of each job

More information: https://github.com/canonical/get-workflow-version-action/issues/2