### PR TITLE
build images for arm64

### DIFF
--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -22,6 +22,7 @@ env:
   DOCKER_DIRECTORY: docker/images
   PLATFORMS: |
     linux/amd64
+    linux/arm64
   PATH_TO_DEPLOY_SINGLE_DOCKER_IMAGE_WORKFLOW: .github/workflows/deploy-single-docker-image.yml
   PATH_TO_DEPLOY_DOCKER_IMAGES_WORKFLOW: .github/workflows/deploy-docker-images.yml
 


### PR DESCRIPTION
The arm64 platform is becoming more common for desktop use. Docker on macs have amd64 emulation but it has caused some issues with everest that don't appear with native builds.

https://github.com/EVerest/everest-demo/issues/99