### PR TITLE
Bump package versions, make ci pipeline more forkable and add arm/v7 platform

### DIFF
--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -102,7 +102,7 @@ jobs:
         ${{ needs.env-setup.outputs.path_to_deploy_docker_images_workflow }}
       build_args: |
         BASE_IMAGE_TAG=${{ needs.run-env-base.outputs.one_image_tag_short }}
-        
+        BASE_IMAGE_REGISTRY=${{ needs.env-setup.outputs.docker_registry }}/${{ github.repository_owner }}/${{ needs.env-setup.outputs.repository_name }}
   dev-env-base:
     needs:
       - env-setup
@@ -129,6 +129,7 @@ jobs:
         ${{ needs.env-setup.outputs.path_to_deploy_docker_images_workflow }}
       build_args: |
         BASE_IMAGE_TAG=${{ needs.build-env-base.outputs.one_image_tag_short }}
+        BASE_IMAGE_REGISTRY=${{ needs.env-setup.outputs.docker_registry }}/${{ github.repository_owner }}/${{ needs.env-setup.outputs.repository_name }}
   build-kit-base:
     needs:
       - env-setup
@@ -155,6 +156,7 @@ jobs:
         ${{ needs.env-setup.outputs.path_to_deploy_docker_images_workflow }}
       build_args: |
         BASE_IMAGE_TAG=${{ needs.build-env-base.outputs.one_image_tag_short }}
+        BASE_IMAGE_REGISTRY=${{ needs.env-setup.outputs.docker_registry }}/${{ github.repository_owner }}/${{ needs.env-setup.outputs.repository_name }}
   # Include deprecated images for backwards compatibility
   deprecated-everest-clang-format:
     if: ${{ needs.env-setup.outputs.build_deprecated_images == 'true' }}

--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -23,6 +23,7 @@ env:
   PLATFORMS: |
     linux/amd64
     linux/arm64
+    linux/arm/v7
   PATH_TO_DEPLOY_SINGLE_DOCKER_IMAGE_WORKFLOW: .github/workflows/deploy-single-docker-image.yml
   PATH_TO_DEPLOY_DOCKER_IMAGES_WORKFLOW: .github/workflows/deploy-docker-images.yml
 

--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -17,6 +17,10 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: deploy-docker-images-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
   DOCKER_DIRECTORY: docker/images

--- a/docker/images/build-env-base/Dockerfile
+++ b/docker/images/build-env-base/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1
 ARG BASE_IMAGE_TAG=latest
-FROM ghcr.io/everest/everest-ci/run-env-base:${BASE_IMAGE_TAG}
+ARG BASE_IMAGE_REGISTRY=ghcr.io/everest/everest-ci
+FROM ${BASE_IMAGE_REGISTRY}/run-env-base:${BASE_IMAGE_TAG}
 
 # renovate: datasource=repology depName=debian_12/git versioning=loose
 ENV GIT_VERSION=1:2.39.5-0+deb12u3

--- a/docker/images/build-env-base/Dockerfile
+++ b/docker/images/build-env-base/Dockerfile
@@ -68,9 +68,9 @@ ENV LIBBOOST_ALL_DEV_VERSION=1.74.0.3
 # renovate: datasource=repology depName=debian_12/libsqlite3-dev versioning=loose
 ENV LIBSQLITE3_DEV_VERSION=3.40.1-2+deb12u2
 # renovate: datasource=repology depName=debian_12/openssl versioning=loose
-ENV LIBSSL_DEV_VERSION=3.0.18-1~deb12u2
+ENV LIBSSL_DEV_VERSION=3.0.19-1~deb12u2
 # renovate: datasource=repology depName=debian_12/nodejs versioning=loose
-ENV LIBNODE_DEV_VERSION=18.20.4+dfsg-1~deb12u1
+ENV LIBNODE_DEV_VERSION=18.20.4+dfsg-1~deb12u2
 # renovate: datasource=repology depName=debian_12/pkg-config versioning=loose
 ENV PKG_CONFIG_VERSION=1.8.1-1
 # renovate: datasource=repology depName=debian_12/libpcap-dev versioning=loose

--- a/docker/images/build-kit-base/Dockerfile
+++ b/docker/images/build-kit-base/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1
 ARG BASE_IMAGE_TAG=latest
-FROM ghcr.io/everest/everest-ci/build-env-base:${BASE_IMAGE_TAG}
+ARG BASE_IMAGE_REGISTRY=ghcr.io/everest/everest-ci
+FROM ${BASE_IMAGE_REGISTRY}/build-env-base:${BASE_IMAGE_TAG}
 
 ENV WORKSPACE_PATH=/workspace
 ARG EXT_MOUNT=/ext

--- a/docker/images/dev-env-base/Dockerfile
+++ b/docker/images/dev-env-base/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1
 ARG BASE_IMAGE_TAG=latest
-FROM ghcr.io/everest/everest-ci/build-env-base:${BASE_IMAGE_TAG}
+ARG BASE_IMAGE_REGISTRY=ghcr.io/everest/everest-ci
+FROM ${BASE_IMAGE_REGISTRY}/build-env-base:${BASE_IMAGE_TAG}
 
 ARG USERNAME=docker
 ARG USER_UID=1000

--- a/docker/images/dev-env-base/Dockerfile
+++ b/docker/images/dev-env-base/Dockerfile
@@ -68,11 +68,11 @@ ENV CA_CERTIFICATES_VERSION=20230311+deb12u1
 ENV CURL_VERSION=7.88.1-10+deb12u14
 
 # Not managed by renovate, because no available datasource
-ENV DOCKER_CE_VERSION=5:27.0.3-1~debian.12~bookworm
-ENV DOCKER_CE_CLI_VERSION=5:27.1.1-1~debian.12~bookworm
-ENV CONTAINERD_IO_VERSION=1.7.19-1
-ENV DOCKER_BUILDX_PLUGIN_VERSION=0.16.1-1~debian.12~bookworm
-ENV DOCKER_COMPOSE_PLUGIN_VERSION=2.29.1-1~debian.12~bookworm
+ENV DOCKER_CE_VERSION=5:29.5.0-1~debian.12~bookworm
+ENV DOCKER_CE_CLI_VERSION=5:29.5.0-1~debian.12~bookworm
+ENV CONTAINERD_IO_VERSION=2.2.3-1~debian.12~bookworm
+ENV DOCKER_BUILDX_PLUGIN_VERSION=0.34.0-1~debian.12~bookworm
+ENV DOCKER_COMPOSE_PLUGIN_VERSION=5.1.3-1~debian.12~bookworm
 
 # Development Tools - Docker
 RUN apt update \

--- a/docker/images/run-env-base/Dockerfile
+++ b/docker/images/run-env-base/Dockerfile
@@ -2,7 +2,7 @@
 FROM debian:12-slim
 
 # renovate: datasource=repology depName=debian_12/openjdk-17 versioning=loose
-ENV OPENJDK_17_JRE_VERSION=17.0.18+8-1~deb12u1
+ENV OPENJDK_17_JRE_VERSION=17.0.19+10-1~deb12u2
 # renovate: datasource=repology depName=debian_12/nodejs versioning=loose
 ENV NODEJS_VERSION=18.20.4+dfsg-1~deb12u1
 # renovate: datasource=repology depName=debian_12/npm versioning=loose
@@ -20,7 +20,7 @@ ENV LIBBOOST_CHRONO1_74_0_VERSION=1.74.0+ds1-21
 # renovate: datasource=repology depName=debian_12/boost1.74 versioning=loose
 ENV LIBBOOST_SYSTEM1_74_0_VERSION=1.74.0+ds1-21
 # renovate: datasource=repology depName=debian_12/openssl versioning=loose
-ENV LIBSSL3_VERSION=3.0.18-1~deb12u2
+ENV LIBSSL3_VERSION=3.0.19-1~deb12u2
 # renovate: datasource=repology depName=debian_12/curl versioning=loose
 ENV LIBCURL4_VERSION=7.88.1-10+deb12u14
 # renovate: datasource=repology depName=debian_12/libcap2 versioning=loose

--- a/docker/images/run-env-base/Dockerfile
+++ b/docker/images/run-env-base/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:12-slim
 # renovate: datasource=repology depName=debian_12/openjdk-17 versioning=loose
 ENV OPENJDK_17_JRE_VERSION=17.0.19+10-1~deb12u2
 # renovate: datasource=repology depName=debian_12/nodejs versioning=loose
-ENV NODEJS_VERSION=18.20.4+dfsg-1~deb12u1
+ENV NODEJS_VERSION=18.20.4+dfsg-1~deb12u2
 # renovate: datasource=repology depName=debian_12/npm versioning=loose
 ENV NPM_VERSION=9.2.0~ds1-1
 # renovate: datasource=repology depName=debian_12/python3-pip versioning=loose


### PR DESCRIPTION
My initial goal was to add armv7 support. While building that, I noticed that it would be nice to be able to execute the CI pipeline on forks as well to test everything everything easily. Also I think adding a concurrency group makes sense to prevent multiple pushes happening to the same target at the same time. And for getting everything to build again, I also had to update some packages.

Everything is split into individual commits, so it might make sense to review them individually and merge without squashing. 

I can also split this out into multiple pull requests if it makes sense, but as all changes were necessary to get a successful build again I decided against it for now.