### PR TITLE
feat: add eebus build deps to base images

### DIFF
--- a/docker/images/build-env-base/Dockerfile
+++ b/docker/images/build-env-base/Dockerfile
@@ -138,6 +138,28 @@ RUN git clone https://github.com/EVerest/everest-cmake.git ${EVEREST_CMAKE_PATH}
     && git checkout ${EVEREST_CMAKE_VERSION} \
     && rm -r .git
 
+# Install grpc and grpc-extended-cpp-plugin
+# renovate: datasource=github-tags depName=grpc/grpc
+ENV GRPC_VERSION=v1.71.0
+# renovate: datasource=github-releases depName=EVerest/grpc-extended-cpp-plugin versioning=loose
+ENV GRPC_EXTENDED_CPP_PLUGIN_VERSION=v0.2.0
+RUN tmpdir=$(mktemp -d) \
+    && cd $tmpdir \
+    && git clone --depth 1 --recurse-submodules --shallow-submodules --branch ${GRPC_VERSION} https://github.com/grpc/grpc.git \
+    && git clone --branch ${GRPC_EXTENDED_CPP_PLUGIN_VERSION} https://github.com/EVerest/grpc-extended-cpp-plugin.git \
+    && cmake -B build -S grpc-extended-cpp-plugin -G Ninja -D gRPC_INSTALL=ON \
+    && cmake --build build \
+    && cmake --install build \
+    && rm -rf $tmpdir
+
+# renovate: datasource=pypi depName=grpcio
+ENV GRPCIO_VERSION=1.71.0
+# renovate: datasource=pypi depName=grpcio-tools
+ENV GRPCIO_TOOLS_VERSION=1.71.0
+RUN python3 -m pip install --break-system-packages \
+    grpcio==${GRPCIO_VERSION} \
+    grpcio-tools==${GRPCIO_TOOLS_VERSION}
+
 COPY entrypoint.sh /entrypoint.sh
 ARG TARGETARCH
 COPY entrypoint_wrapper.sh /entrypoint_wrapper.sh

--- a/docker/images/run-env-base/Dockerfile
+++ b/docker/images/run-env-base/Dockerfile
@@ -73,6 +73,17 @@ RUN python3 -m pip install --break-system-packages \
     py4j==${PY4J_VERSION} \
     aiofile==${AIOFILE_VERSION}
 
+# Install go (used by the EEBUS go client)
+# renovate: datasource=golang-version depName=go
+ENV GO_VERSION=1.24.2
+ADD https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz /tmp/go.tar.gz
+RUN if [ -d /usr/local/go ]; then \
+        echo "Go is already installed"; \
+    else \
+        tar -C /usr/local -xzf /tmp/go.tar.gz; \
+    fi
+ENV PATH="/usr/local/go/bin:${PATH}"
+
 COPY entrypoint.sh /entrypoint.sh
 ARG TARGETARCH
 COPY entrypoint_wrapper.sh /entrypoint_wrapper.sh


### PR DESCRIPTION
Add go to run-env-base and grpc, grpc-extended-cpp-plugin and grpcio/grpcio-tools to build-env-base so downstream repos can drop these from their own build-kit Dockerfiles.